### PR TITLE
Add Revit add-in sample and build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # 20250616
+
+This repository contains a minimal Revit HelloCodex add-in and a Python example used for testing Codex.
+
+## Python Example
+Run `python hello.py` to print a greeting.
+
+## Revit Add-in
+When run from **Add-Ins -> External Tools**, the add-in shows a task dialog that says "Hello Codex!".
+
+### Build and Deploy
+1. Set the `REVIT_API_PATH` environment variable to the folder that contains
+   `RevitAPI.dll` and `RevitAPIUI.dll`.
+2. Open a **Developer Command Prompt for VS 2022** and run
+   `codex_build_deploy.bat` from the repository root (for example,
+   `D:\02 Code\07 Revit Addin\20250616`).
+   The script invokes *msbuild* on `RevitAddin\RevitAddin.csproj` in
+   **Release**/`x64` mode. The resulting `HelloCodex.dll` is copied together
+   with the `HelloCodex.addin` manifest to
+   `C:\Users\Administrator\AppData\Roaming\Autodesk\Revit\Addins\2022`.
+3. Start Revit 2022 and choose **HelloCodex** from **Add-Ins -> External Tools**.

--- a/RevitAddin/HelloCodex.addin
+++ b/RevitAddin/HelloCodex.addin
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<RevitAddIns>
+  <AddIn Type="Command">
+    <Name>HelloCodex</Name>
+    <Assembly>%AppData%\Autodesk\Revit\Addins\2022\HelloCodex.dll</Assembly>
+    <AddInId>F20B6E8B-9A27-4860-B092-5D9126F3A847</AddInId>
+    <FullClassName>HelloCodex.HelloCodexCommand</FullClassName>
+    <VendorId>CODX</VendorId>
+    <VendorDescription>Codex</VendorDescription>
+  </AddIn>
+</RevitAddIns>

--- a/RevitAddin/HelloCodexCommand.cs
+++ b/RevitAddin/HelloCodexCommand.cs
@@ -1,0 +1,15 @@
+using Autodesk.Revit.UI;
+using Autodesk.Revit.Attributes;
+
+namespace HelloCodex
+{
+    [Transaction(TransactionMode.Manual)]
+    public class HelloCodexCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, Autodesk.Revit.DB.ElementSet elements)
+        {
+            TaskDialog.Show("Hello Codex", "Hello Codex!");
+            return Result.Succeeded;
+        }
+    }
+}

--- a/RevitAddin/RevitAddin.csproj
+++ b/RevitAddin/RevitAddin.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <PlatformTarget>x64</PlatformTarget>
+    <OutputPath>bin\$(PlatformTarget)\$(Configuration)\</OutputPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="RevitAPI">
+      <HintPath>$(REVIT_API_PATH)\RevitAPI.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="RevitAPIUI">
+      <HintPath>$(REVIT_API_PATH)\RevitAPIUI.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+</Project>

--- a/codex_build_deploy.bat
+++ b/codex_build_deploy.bat
@@ -1,0 +1,25 @@
+@echo off
+setlocal
+
+REM Build and deploy HelloCodex Revit add-in
+set "CONFIG=Release"
+set "PLATFORM=x64"
+
+set "PROJECT=%~dp0RevitAddin\RevitAddin.csproj"
+
+msbuild "%PROJECT%" /p:Configuration=%CONFIG% /p:Platform=%PLATFORM%
+if errorlevel 1 (
+    echo Build failed.
+    exit /b 1
+)
+
+set "DEST=%AppData%\Autodesk\Revit\Addins\2022"
+if not exist "%DEST%" (
+    mkdir "%DEST%"
+)
+
+copy "%~dp0RevitAddin\bin\%PLATFORM%\%CONFIG%\HelloCodex.dll" "%DEST%\HelloCodex.dll" /Y
+copy "%~dp0RevitAddin\HelloCodex.addin" "%DEST%\HelloCodex.addin" /Y
+
+echo Deployment completed.
+endlocal

--- a/hello.py
+++ b/hello.py
@@ -1,0 +1,1 @@
+print("Hello Codex!")


### PR DESCRIPTION
## Summary
- implement `HelloCodexCommand` and Revit project files
- add `codex_build_deploy.bat` to build with MSBuild and copy output to the Revit Addins folder
- document build steps in README
- include a small `hello.py` example
- clarify that running the batch file builds `HelloCodex.dll` and deploys it to the default Addins folder

## Testing
- `python hello.py`


------
https://chatgpt.com/codex/tasks/task_e_684fdd91cadc83329de112c044bd5082